### PR TITLE
Add topic trends visualization to dashboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm
 gradio>=4.0.0
 requests
 beautifulsoup4
+plotly

--- a/src/dashboard_gradio.py
+++ b/src/dashboard_gradio.py
@@ -38,8 +38,14 @@ from articles a
 join sources s on s.id = a.source_id
 where date(coalesce(a.published_at, a.inserted_at)) between :start_day and :end_day
   and a.id not in (select article_id from article_dupes)
-group by day, source, topic
-order by day asc, source asc, topic asc
+group by
+  day,
+  source,
+  coalesce(a.topic,'general')
+order by
+  day asc,
+  source asc,
+  coalesce(a.topic,'general') asc
 """
 
 


### PR DESCRIPTION
## Summary
- add aggregated topic trend query for the last 30 days grouped by source
- render a stacked bar chart and detailed table with source/topic filters in the Gradio dashboard
- include Plotly dependency to support the new interactive visualization

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e28ac6960c83328f148f7b957bb411