### PR TITLE
Implement taxonomy-driven classification workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: init install db ingest dedupe summarize align dash all
+.PHONY: init install db ingest dedupe summarize align classify dash all
 
 .venv/.requirements-installed: requirements.txt
 	python -m venv .venv
@@ -17,7 +17,12 @@ db: install
 
 # Ingestion RSS
 ingest: install
-	. .venv/bin/activate && python src/ingest_rss.py
+        . .venv/bin/activate && python src/ingest_rss.py
+
+SINCE ?=
+
+classify: install
+        . .venv/bin/activate && python src/classify_articles.py $(if $(SINCE),--since=$(SINCE),)
 
 # Déduplication
 dedupe: install
@@ -36,4 +41,4 @@ dash: install
 	. .venv/bin/activate && python src/dashboard_gradio.py
 
 # Pipeline complet pour aujourd’hui
-all: ingest dedupe summarize align
+all: ingest classify summarize align

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ db: install
 
 # Ingestion RSS
 ingest: install
-        . .venv/bin/activate && python src/ingest_rss.py
+	. .venv/bin/activate && python src/ingest_rss.py
 
 SINCE ?=
 
 classify: install
-        . .venv/bin/activate && python src/classify_articles.py $(if $(SINCE),--since=$(SINCE),)
+	. .venv/bin/activate && python src/classify_articles.py $(if $(SINCE),--since=$(SINCE),)
 
 # Déduplication
 dedupe: install

--- a/config/themes_config.json
+++ b/config/themes_config.json
@@ -1,0 +1,63 @@
+{
+  "Politique": [
+    "élections", "président", "gouvernement", "ministre", "assemblée",
+    "sénat", "loi", "réforme", "parti", "campagne", "maire", "vote", "député"
+  ],
+  "Économie": [
+    "inflation", "PIB", "croissance", "banque", "entreprise", "emploi",
+    "chômage", "bourse", "marché", "impôt", "salaire", "budget", "finance", "taxe"
+  ],
+  "Société": [
+    "éducation", "école", "enseignant", "logement", "pauvreté", "discrimination",
+    "égalité", "sécurité", "police", "famille", "religion", "migrants", "travail"
+  ],
+  "International": [
+    "guerre", "Ukraine", "Russie", "États-Unis", "ONU", "OTAN", "diplomatie",
+    "conflit", "migrants", "accord", "sanction", "ambassade", "israël", "palestine"
+  ],
+  "Environnement": [
+    "écologie", "climat", "CO2", "pollution", "biodiversité", "énergies",
+    "renouvelable", "sécheresse", "canicule", "incendie", "forêt", "recyclage"
+  ],
+  "Santé": [
+    "hôpital", "médecin", "maladie", "pandémie", "vaccin", "covid",
+    "cancer", "santé publique", "soins", "médicament", "sécurité sociale"
+  ],
+  "Science et Technologie": [
+    "innovation", "IA", "intelligence artificielle", "robot", "espace",
+    "recherche", "startup", "ordinateur", "cybersécurité", "nucléaire",
+    "réseau social", "internet", "science"
+  ],
+  "Culture": [
+    "cinéma", "musique", "livre", "roman", "théâtre", "exposition", "festival",
+    "peinture", "art", "auteur", "acteur", "film", "série", "prix"
+  ],
+  "Sport": [
+    "football", "rugby", "tennis", "cyclisme", "JO", "basket", "match",
+    "ligue", "championnat", "record", "entraîneur", "athlète", "victoire"
+  ],
+  "Justice": [
+    "procès", "tribunal", "justice", "avocat", "jugement", "plainte",
+    "enquête", "prison", "condamnation", "victime", "police judiciaire"
+  ],
+  "Faits divers": [
+    "accident", "meurtre", "disparition", "incendie", "catastrophe",
+    "policier", "crime", "drogue", "vol", "agression"
+  ],
+  "Transport": [
+    "train", "avion", "route", "voiture", "trafic", "SNCF", "aéroport",
+    "RATP", "métro", "bus", "vélo", "autoroute", "grève"
+  ],
+  "Europe": [
+    "Union européenne", "Bruxelles", "Parlement européen", "euro",
+    "Commission européenne", "Schengen", "migration", "directive", "élections européennes"
+  ],
+  "Numérique": [
+    "réseau social", "données", "numérique", "cyberattaque", "téléphone",
+    "application", "ordinateur", "logiciel", "cloud", "start-up", "plateforme"
+  ],
+  "Culture populaire": [
+    "mode", "influenceur", "télévision", "streaming", "jeu vidéo",
+    "TikTok", "YouTube", "célébrité", "people", "tendances"
+  ]
+}

--- a/sql/schema_postgres.sql
+++ b/sql/schema_postgres.sql
@@ -18,7 +18,9 @@ create table if not exists articles (
   published_at timestamptz,
   topic text,
   raw jsonb,
-  inserted_at timestamptz default now()
+  content_hash text,
+  inserted_at timestamptz default now(),
+  updated_at timestamptz default now()
 );
 
 create unique index if not exists idx_articles_source_guid
@@ -26,6 +28,23 @@ create unique index if not exists idx_articles_source_guid
   where guid is not null;
 create unique index if not exists idx_articles_source_link
   on articles(source_id, link);
+
+create table if not exists article_themes (
+  id bigserial primary key,
+  article_id bigint references articles(id) on delete cascade,
+  theme text not null,
+  confidence real not null,
+  model_version text not null,
+  taxonomy_version text not null,
+  content_hash text not null,
+  classified_at timestamptz default now()
+);
+
+create index if not exists idx_article_themes_article
+  on article_themes(article_id);
+
+create index if not exists idx_article_themes_hash
+  on article_themes(content_hash);
 
 -- Déduplication logique multi-sources
 create table if not exists article_dupes (

--- a/sql/schema_sqlite.sql
+++ b/sql/schema_sqlite.sql
@@ -15,13 +15,29 @@ create table if not exists articles (
   published_at text,
   topic text,
   raw text,
-  inserted_at text default (datetime('now'))
+  content_hash text,
+  inserted_at text default (datetime('now')),
+  updated_at text default (datetime('now'))
 );
 create unique index if not exists idx_articles_source_guid
   on articles(source_id, guid)
   where guid is not null;
 create unique index if not exists idx_articles_source_link
   on articles(source_id, link);
+create table if not exists article_themes (
+  id integer primary key autoincrement,
+  article_id int references articles(id) on delete cascade,
+  theme text not null,
+  confidence real not null,
+  model_version text not null,
+  taxonomy_version text not null,
+  content_hash text not null,
+  classified_at text default (datetime('now'))
+);
+create index if not exists idx_article_themes_article
+  on article_themes(article_id);
+create index if not exists idx_article_themes_hash
+  on article_themes(content_hash);
 create table if not exists article_dupes (
   id integer primary key autoincrement,
   article_id int,

--- a/src/classify_articles.py
+++ b/src/classify_articles.py
@@ -1,0 +1,263 @@
+import argparse
+import json
+import logging
+import os
+import re
+import hashlib
+from pathlib import Path
+from typing import Iterable
+
+import requests
+from sqlalchemy import text
+from dotenv import load_dotenv
+
+from db import get_engine
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s [%(name)s] %(message)s")
+LOG = logging.getLogger(__name__)
+
+CONFIG_PATH = Path("config/themes_config.json")
+CACHE_PATH = Path("data/classify_cache.jsonl")
+KEYWORD_MODEL_VERSION = "keyword_v1"
+LLM_MODEL = os.getenv("CLASSIFY_MODEL", os.getenv("OPENAI_MODEL", "gpt-4.1-mini"))
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_BASE = os.getenv("OPENAI_BASE", "https://api.openai.com/v1")
+
+
+def load_taxonomy() -> tuple[dict[str, list[str]], str]:
+    data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    normalized = {k: [w.lower() for w in v] for k, v in data.items()}
+    digest = hashlib.sha1(json.dumps(data, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()
+    taxonomy_version = digest[:12]
+    return normalized, taxonomy_version
+
+
+def canonicalize_theme(name: str, taxonomy: dict[str, list[str]]) -> str | None:
+    lowered = name.strip().lower()
+    for theme in taxonomy.keys():
+        if theme.lower() == lowered:
+            return theme
+    return None
+
+
+def keyword_scores(text: str, taxonomy: dict[str, list[str]]) -> list[tuple[str, int]]:
+    scores: list[tuple[str, int]] = []
+    lowered = text.lower()
+    for theme, keywords in taxonomy.items():
+        count = 0
+        for kw in keywords:
+            pattern = rf"\b{re.escape(kw)}\b"
+            if re.search(pattern, lowered, flags=re.IGNORECASE):
+                count += 1
+        if count:
+            scores.append((theme, count))
+    return scores
+
+
+def keyword_to_confidence(count: int) -> float:
+    base = 0.6
+    if count <= 1:
+        return base
+    if count == 2:
+        return 0.75
+    if count == 3:
+        return 0.85
+    return 0.95
+
+
+def load_cache() -> dict[str, list[tuple[str, float]]]:
+    cache: dict[str, list[tuple[str, float]]] = {}
+    if not CACHE_PATH.exists():
+        return cache
+    with CACHE_PATH.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+                cache[payload["key"]] = [(item["theme"], float(item["confidence"])) for item in payload["themes"]]
+            except Exception:
+                continue
+    return cache
+
+
+def save_cache(cache: dict[str, list[tuple[str, float]]]) -> None:
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with CACHE_PATH.open("w", encoding="utf-8") as fh:
+        for key, items in cache.items():
+            fh.write(json.dumps({
+                "key": key,
+                "themes": [{"theme": theme, "confidence": conf} for theme, conf in items],
+            }, ensure_ascii=False) + "\n")
+
+
+def call_llm(text: str, taxonomy: Iterable[str]) -> list[tuple[str, float]]:
+    if not OPENAI_API_KEY:
+        LOG.warning("OPENAI_API_KEY manquant, impossible d'utiliser le fallback LLM")
+        return []
+
+    prompt = (
+        "Tu es un classifieur d'articles d'actualité. "
+        "Analyse le texte fourni et renvoie uniquement un objet JSON de la forme "
+        "{\"themes\": [{\"theme\": \"nom\", \"confidence\": 0.x}]} sans aucun texte additionnel. "
+        "Choisis les thèmes dans la liste suivante: " + ", ".join(sorted(taxonomy)) + ". "
+        "Confidence doit être un nombre entre 0 et 1.\n\nARTICLE:\n" + text.strip()[:6000]
+    )
+
+    headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
+    payload = {
+        "model": LLM_MODEL,
+        "messages": [
+            {"role": "system", "content": "Tu es un assistant spécialisé en classification de news."},
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 300,
+    }
+
+    try:
+        resp = requests.post(
+            f"{OPENAI_API_BASE}/chat/completions", json=payload, headers=headers, timeout=60
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        LOG.warning("Appel LLM en échec: %s", exc)
+        return []
+
+    content = resp.json()["choices"][0]["message"]["content"].strip()
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        LOG.warning("Réponse LLM invalide: %s", content)
+        return []
+
+    items = []
+    for entry in data.get("themes", []):
+        name = entry.get("theme") or entry.get("name")
+        conf = entry.get("confidence")
+        try:
+            conf_val = float(conf)
+        except (TypeError, ValueError):
+            continue
+        if not name:
+            continue
+        items.append((str(name), max(0.0, min(1.0, conf_val))))
+    return items
+
+
+def classify_text(text: str, taxonomy: dict[str, list[str]], taxonomy_version: str, cache: dict[str, list[tuple[str, float]]]) -> tuple[str, list[tuple[str, float]]]:
+    scores = keyword_scores(text, taxonomy)
+    if scores:
+        results = [(theme, keyword_to_confidence(count)) for theme, count in scores]
+        return KEYWORD_MODEL_VERSION, results
+
+    cache_key = hashlib.sha1((taxonomy_version + text).encode("utf-8")).hexdigest()
+    if cache_key in cache:
+        return f"{LLM_MODEL}_cached", cache[cache_key]
+
+    llm_results = call_llm(text, taxonomy.keys())
+    if llm_results:
+        cache[cache_key] = llm_results
+        return LLM_MODEL, llm_results
+
+    return KEYWORD_MODEL_VERSION, []
+
+
+def fetch_articles(engine, since: str | None) -> list[dict]:
+    with engine.begin() as cxn:
+        conditions = ["a.content_hash is not null"]
+        params: dict[str, str] = {}
+        if since:
+            conditions.append("date(coalesce(a.published_at, a.inserted_at)) >= :since")
+            params["since"] = since
+        conditions.append(
+            "not exists (select 1 from article_themes t where t.article_id = a.id and t.content_hash = a.content_hash)"
+        )
+        sql = "select a.id, a.title, a.summary, a.content, a.content_hash from articles a"
+        if conditions:
+            sql += " where " + " and ".join(conditions)
+        sql += " order by coalesce(a.published_at, a.inserted_at)"
+        rows = cxn.execute(text(sql), params).mappings().all()
+        return [dict(row) for row in rows]
+
+
+def process_articles(since: str | None = None) -> None:
+    taxonomy, taxonomy_version = load_taxonomy()
+    cache = load_cache()
+    eng = get_engine()
+    to_classify = fetch_articles(eng, since)
+    if not to_classify:
+        LOG.info("Aucun article à classifier")
+        return
+
+    with eng.begin() as cxn:
+        for art in to_classify:
+            content_hash = art.get("content_hash")
+            if not content_hash:
+                LOG.debug("Article %s sans content_hash, skip", art["id"])
+                continue
+
+            cxn.execute(text("delete from article_themes where article_id = :id and content_hash != :hash"), {
+                "id": art["id"],
+                "hash": content_hash,
+            })
+
+            text_parts = [art.get("title"), art.get("summary"), art.get("content")]
+            payload = "\n\n".join([p for p in text_parts if p])
+            if not payload.strip():
+                LOG.debug("Article %s sans contenu textuel", art["id"])
+                continue
+
+            model_version, results = classify_text(payload, taxonomy, taxonomy_version, cache)
+            if not results:
+                LOG.info("Aucun thème trouvé pour l'article %s", art["id"])
+                continue
+
+            cxn.execute(text("delete from article_themes where article_id = :id and content_hash = :hash"), {
+                "id": art["id"],
+                "hash": content_hash,
+            })
+
+            seen = set()
+            for theme, confidence in results:
+                canonical = theme if theme in taxonomy else canonicalize_theme(theme, taxonomy)
+                if not canonical:
+                    continue
+                if canonical in seen:
+                    continue
+                seen.add(canonical)
+                cxn.execute(
+                    text(
+                        """
+                        insert into article_themes(
+                            article_id, theme, confidence, model_version, taxonomy_version, content_hash
+                        )
+                        values(:article_id, :theme, :confidence, :model_version, :taxonomy_version, :content_hash)
+                        """
+                    ),
+                    {
+                        "article_id": art["id"],
+                        "theme": canonical,
+                        "confidence": float(confidence),
+                        "model_version": model_version,
+                        "taxonomy_version": taxonomy_version,
+                        "content_hash": content_hash,
+                    },
+                )
+            LOG.info("Article %s classé (%s)", art["id"], model_version)
+
+    save_cache(cache)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Classification des articles selon la taxonomie locale")
+    parser.add_argument("--since", dest="since", help="Date (YYYY-MM-DD) à partir de laquelle relancer la classification")
+    args = parser.parse_args()
+    process_articles(args.since)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/classify_articles.py
+++ b/src/classify_articles.py
@@ -11,7 +11,7 @@ import requests
 from sqlalchemy import text
 from dotenv import load_dotenv
 
-from db import get_engine
+from db import get_engine, init_schema
 
 load_dotenv()
 
@@ -187,6 +187,8 @@ def fetch_articles(engine, since: str | None) -> list[dict]:
 def process_articles(since: str | None = None) -> None:
     taxonomy, taxonomy_version = load_taxonomy()
     cache = load_cache()
+    # Assure que le schéma minimal est en place (article_themes notamment)
+    init_schema()
     eng = get_engine()
     to_classify = fetch_articles(eng, since)
     if not to_classify:

--- a/src/ingest_rss.py
+++ b/src/ingest_rss.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup
 from sqlalchemy import text
 from dotenv import load_dotenv
 
-from db import get_engine
+from db import get_engine, init_schema
 
 # SSL CA
 try:
@@ -179,6 +179,7 @@ def _fetch_article_content(url: str) -> str | None:
     return _extract_main_text(resp.text)
 
 def upsert_sources():
+    init_schema()
     engine = get_engine()
     with engine.begin() as cxn:
         for s in CFG["sources"]:
@@ -190,6 +191,7 @@ def upsert_sources():
             """), s)
 
 def ingest():
+    init_schema()
     engine = get_engine()
     with engine.begin() as cxn:
         for s in CFG["sources"]:
@@ -253,7 +255,7 @@ def ingest():
                 if link and (not existing or existing.get("content") is None or existing.get("content_hash") != content_hash):
                     content = _fetch_article_content(link)
 
-                dialect = cxn.connection.dialect.name
+                dialect = cxn.dialect.name
                 published_for_db = dt
                 if dialect == "sqlite" and dt is not None:
                     published_for_db = dt.isoformat()

--- a/src/ingest_rss.py
+++ b/src/ingest_rss.py
@@ -32,6 +32,31 @@ UA = "franceinfo-stats-pipeline/1.0 (+https://github.com/jeromebouchet)"
 TIMEOUT = 15  # secondes
 ARTICLE_TIMEOUT = 20  # secondes
 
+
+def _dt_to_iso(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+    return None
+
+
+def _compute_content_hash(title: str | None, summary: str | None) -> str | None:
+    parts = []
+    if title and title.strip():
+        parts.append(title.strip())
+    if summary and summary.strip():
+        parts.append(summary.strip())
+    if not parts:
+        return None
+    joined = "\n\n".join(parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
 def _ssl_context():
     ctx = ssl.create_default_context(cafile=CERT_FILE) if CERT_FILE else ssl.create_default_context()
     # pas d’insecure ici !
@@ -185,39 +210,68 @@ def ingest():
 
                 guid = _guid(e) or None
                 link = e.get("link")
+                summary = e.get("summary") or e.get("description")
+                content_hash = _compute_content_hash(e.get("title"), summary)
+
+                published_iso = _dt_to_iso(dt)
 
                 existing = None
+                candidates: dict[int, dict] = {}
                 if guid:
-                    existing = cxn.execute(
+                    for row in cxn.execute(
                         text(
-                            "select id, content from articles "
-                            "where source_id = :source_id and guid = :guid"
+                            "select id, content, content_hash, published_at "
+                            "from articles where source_id = :source_id and guid = :guid"
                         ),
                         {"source_id": source_id, "guid": guid},
-                    ).mappings().first()
-                if not existing and link:
-                    existing = cxn.execute(
+                    ).mappings():
+                        candidates[row["id"]] = dict(row)
+                if link:
+                    for row in cxn.execute(
                         text(
-                            "select id, content from articles "
-                            "where source_id = :source_id and link = :link"
+                            "select id, content, content_hash, published_at "
+                            "from articles where source_id = :source_id and link = :link"
                         ),
                         {"source_id": source_id, "link": link},
-                    ).mappings().first()
+                    ).mappings():
+                        candidates[row["id"]] = dict(row)
+
+                if candidates:
+                    for cand in candidates.values():
+                        cand_iso = _dt_to_iso(cand.get("published_at"))
+                        if cand_iso == published_iso or (cand_iso is None and published_iso is None):
+                            existing = cand
+                            break
+                    if not existing:
+                        existing = next(iter(candidates.values()))
+
+                if existing and content_hash and existing.get("content_hash") == content_hash:
+                    LOG.debug("Article %s déjà présent (hash identique), skip", link or guid)
+                    continue
 
                 content = None
-                if link and (not existing or existing["content"] is None):
+                if link and (not existing or existing.get("content") is None or existing.get("content_hash") != content_hash):
                     content = _fetch_article_content(link)
+
+                dialect = cxn.connection.dialect.name
+                published_for_db = dt
+                if dialect == "sqlite" and dt is not None:
+                    published_for_db = dt.isoformat()
+                now = datetime.now(timezone.utc)
+                updated_at = now if dialect != "sqlite" else now.isoformat()
 
                 params = {
                     "guid": guid,
                     "link": link,
                     "title": e.get("title"),
-                    "summary": e.get("summary"),
+                    "summary": summary,
                     "content": content,
-                    "published_at": dt,
+                    "published_at": published_for_db,
                     "topic": s.get("topic"),
                     "raw": raw,
                     "source_id": source_id,
+                    "content_hash": content_hash,
+                    "updated_at": updated_at,
                 }
 
                 try:
@@ -232,7 +286,9 @@ def ingest():
                                     published_at = :published_at,
                                     topic = :topic,
                                     raw = :raw,
-                                    content = coalesce(:content, content)
+                                    content = coalesce(:content, content),
+                                    content_hash = :content_hash,
+                                    updated_at = :updated_at
                                 where id = :id
                                 """
                             ),
@@ -242,8 +298,12 @@ def ingest():
                         cxn.execute(
                             text(
                                 """
-                                insert into articles(source_id, guid, link, title, summary, content, published_at, topic, raw)
-                                values(:source_id, :guid, :link, :title, :summary, :content, :published_at, :topic, :raw)
+                                insert into articles(
+                                    source_id, guid, link, title, summary, content,
+                                    published_at, topic, raw, content_hash, updated_at
+                                )
+                                values(:source_id, :guid, :link, :title, :summary, :content,
+                                       :published_at, :topic, :raw, :content_hash, :updated_at)
                                 """
                             ),
                             params,


### PR DESCRIPTION
## Summary
- add a reusable themes_config.json taxonomy for article classification
- extend the ingestion job with content hashing and skip logic when articles are unchanged
- introduce a keyword-first classifier with optional LLM fallback and persist results in the new article_themes table

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e296f9fad883329648d2f61ca02d61