### PR TITLE
Add theme time-series analytics and peak detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,22 @@ Chaque bloc inclut **scripts prêts à l’emploi**, **prompts** et **commandes*
 
 ## Analyse descriptive
 
-Pour produire des statistiques descriptives (volume d’articles, poids des thèmes, durée moyenne d’un sujet), exécute :
+Pour produire des statistiques descriptives (volume d’articles, poids des thèmes, durée moyenne d’un sujet, corrélations et pics médiatiques), exécute :
 
 ```
-python -m src.descriptive_stats --start-date 2024-01-01 --end-date 2024-01-31
+python -m src.descriptive_stats --start-date 2024-01-01 --end-date 2024-01-31 --top-themes 15
 ```
 
-Les bornes de dates sont optionnelles. La sortie affiche :
+Passe `--top-themes 0` pour afficher tous les thèmes dans les séries temporelles.
+
+Les bornes de dates sont optionnelles (et les paramètres `--top-themes`, `--correlate`, `--z-threshold`, `--min-days` permettent de personnaliser l'analyse). La sortie affiche :
 
 - le nombre d’articles par jour, source et thème ;
 - le poids relatif de chaque thème ;
-- la durée moyenne de « vie médiatique » par thème ainsi que la moyenne générale.
+- la durée moyenne de « vie médiatique » par thème ainsi que la moyenne générale ;
+- la fréquence quotidienne des principaux thèmes ;
+- une matrice de corrélation (option `--correlate énergie écologie` par exemple) ;
+- la détection automatique des pics médiatiques via z-score (paramétrable avec `--z-threshold`).
 
 ---
 


### PR DESCRIPTION
## Summary
- extend the descriptive statistics CLI with time-series aggregation, correlation analysis, and peak detection helpers
- add CLI options for selecting themes and tuning anomaly thresholds, updating the README with usage guidance

## Testing
- python -m compileall src/descriptive_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d6d86cc083329c1f8a7223fae56f