### PR TITLE
Handle delayed articles in summary pipeline

### DIFF
--- a/sql/schema_postgres.sql
+++ b/sql/schema_postgres.sql
@@ -61,6 +61,7 @@ create table if not exists daily_summaries (
   day date not null,
   summary_md text not null,
   created_at timestamptz default now(),
+  updated_at timestamptz default now(),
   unique(day)
 );
 
@@ -70,6 +71,7 @@ create table if not exists topic_summaries (
   topic text not null,
   summary_md text not null,
   created_at timestamptz default now(),
+  updated_at timestamptz default now(),
   unique(day, topic)
 );
 

--- a/sql/schema_sqlite.sql
+++ b/sql/schema_sqlite.sql
@@ -49,7 +49,8 @@ create table if not exists daily_summaries (
   id integer primary key autoincrement,
   day text not null unique,
   summary_md text not null,
-  created_at text default (datetime('now'))
+  created_at text default (datetime('now')),
+  updated_at text default (datetime('now'))
 );
 create table if not exists topic_summaries (
   id integer primary key autoincrement,
@@ -57,6 +58,7 @@ create table if not exists topic_summaries (
   topic text not null,
   summary_md text not null,
   created_at text default (datetime('now')),
+  updated_at text default (datetime('now')),
   unique(day, topic)
 );
 create table if not exists transcripts (

--- a/src/summarize.py
+++ b/src/summarize.py
@@ -1,58 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Summarize France Info articles by day and topic
+"""
+
 import os
 import json
+import requests
 from datetime import date, datetime, timedelta, timezone
 from sqlalchemy import text
 from db import get_engine
 from dotenv import load_dotenv
 
 try:
-    from zoneinfo import ZoneInfo  # py>=3.9
-except ImportError:  # pragma: no cover - fallback for very old python
+    from zoneinfo import ZoneInfo  # Python ≥ 3.9
+except ImportError:
     ZoneInfo = None
 
+# ---------------------------------------------------------------------
+# CONFIG
+# ---------------------------------------------------------------------
+
 load_dotenv()
+
 MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 MAX_TOK = int(os.getenv("SUMMARIZE_MAX_TOKENS", "800"))
 WINDOW_DAYS = max(1, int(os.getenv("SUMMARY_WINDOW_DAYS", "3")))
 MIN_HOUR = int(os.getenv("SUMMARY_MIN_HOUR", "9"))
-TZ_NAME = os.getenv("SUMMARY_TIMEZONE")
+TZ_NAME = os.getenv("SUMMARY_TIMEZONE", "Europe/Paris")
 
 PROMPT_DAILY = open("config/prompts/daily_summary.txt", "r", encoding="utf-8").read()
 PROMPT_TOPIC = open("config/prompts/topic_summary.txt", "r", encoding="utf-8").read()
 
-# Appel API compatible OpenAI (adaptable à autre fournisseur)
-import requests
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_API_BASE = os.getenv("OPENAI_BASE", "https://api.openai.com/v1")
 
+# ---------------------------------------------------------------------
+# UTILS
+# ---------------------------------------------------------------------
 
 def _now() -> datetime:
     """Return timezone-aware now when possible."""
-    if TZ_NAME:
-        if ZoneInfo is not None:
-            try:
-                return datetime.now(ZoneInfo(TZ_NAME))
-            except Exception:
-                pass
-    if ZoneInfo is not None:
+    if TZ_NAME and ZoneInfo is not None:
         try:
-            return datetime.now().astimezone()
+            return datetime.now(ZoneInfo(TZ_NAME))
         except Exception:
             pass
-    return datetime.now()
-
-
-def call_llm(prompt: str) -> str:
-    headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
-    payload = {
-        "model": MODEL,
-        "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": MAX_TOK,
-        "temperature": 0.3,
-    }
-    r = requests.post(f"{OPENAI_API_BASE}/chat/completions", json=payload, headers=headers, timeout=60)
-    r.raise_for_status()
-    return r.json()["choices"][0]["message"]["content"].strip()
+    try:
+        return datetime.now().astimezone()
+    except Exception:
+        return datetime.now()
 
 
 def _parse_dt(value):
@@ -74,12 +71,52 @@ def _parse_dt(value):
 
 
 def _normalize_ts(value):
+    """Convert datetime to UTC-naive for safe comparison."""
     if value is None:
         return None
-    if value.tzinfo is not None:
-        return value.astimezone(timezone.utc).replace(tzinfo=None)
-    return value
+    if value.tzinfo is None:
+        # Interprète les naïves comme TZ_NAME si dispo
+        if TZ_NAME and ZoneInfo is not None:
+            value = value.replace(tzinfo=ZoneInfo(TZ_NAME))
+        else:
+            return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
 
+
+def _latest_ts_from_row(row, cols=("published_at", "inserted_at")):
+    """Pick the latest timestamp among given columns, normalized to UTC-naive."""
+    vals = []
+    for c in cols:
+        ts = _parse_dt(row.get(c))
+        ts = _normalize_ts(ts)
+        if ts:
+            vals.append(ts)
+    return max(vals) if vals else None
+
+
+def call_llm(prompt: str) -> str:
+    headers = {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": MAX_TOK,
+        "temperature": 0.3,
+    }
+    r = requests.post(
+        f"{OPENAI_API_BASE}/chat/completions",
+        json=payload,
+        headers=headers,
+        timeout=60,
+    )
+    r.raise_for_status()
+    return r.json()["choices"][0]["message"]["content"].strip()
+
+# ---------------------------------------------------------------------
+# SQL QUERIES
+# ---------------------------------------------------------------------
 
 SQL_ARTICLES_BY_DAY = """
 select title, summary, topic, published_at, inserted_at
@@ -96,8 +133,12 @@ where date(coalesce(published_at, inserted_at)) = :day
   and id not in (select article_id from article_dupes)
 """
 
+# ---------------------------------------------------------------------
+# CORE
+# ---------------------------------------------------------------------
 
 def iter_days(reference: date, now: datetime) -> list[date]:
+    """Return list of days to summarize (sliding window)."""
     start = reference - timedelta(days=WINDOW_DAYS - 1)
     days = [start + timedelta(days=i) for i in range(WINDOW_DAYS)]
     if MIN_HOUR >= 0:
@@ -113,34 +154,35 @@ def build_daily(day: date):
         rows = cxn.execute(text(SQL_ARTICLES_BY_DAY), {"day": str(day)}).mappings().all()
         if not rows:
             return
+
         latest_ts = None
         for r in rows:
-            candidates = [
-                _parse_dt(r.get("published_at")),
-                _parse_dt(r.get("inserted_at")),
-            ]
-            article_ts = max((ts for ts in candidates if ts), default=None)
-            article_ts = _normalize_ts(article_ts)
+            article_ts = _latest_ts_from_row(r)
             if article_ts and (latest_ts is None or article_ts > latest_ts):
                 latest_ts = article_ts
+
         current = cxn.execute(
             text("select updated_at from daily_summaries where day = :d"),
             {"d": str(day)},
         ).mappings().one_or_none()
+
         if current and latest_ts:
             summary_ts = _normalize_ts(_parse_dt(current.get("updated_at")))
             if summary_ts and latest_ts <= summary_ts:
                 return
+
         bundle = "\n".join([f"- {r['title']} — {r['summary'] or ''}" for r in rows])
         prompt = PROMPT_DAILY.format(date=str(day)) + "\n\nARTICLES:\n" + bundle
         out = call_llm(prompt)
         stamp = _now()
+
         cxn.execute(
             text(
                 """
             insert into daily_summaries(day, summary_md, updated_at)
             values (:d, :s, :u)
-            on conflict(day) do update set summary_md=excluded.summary_md, updated_at=excluded.updated_at
+            on conflict(day) do update
+              set summary_md=excluded.summary_md, updated_at=excluded.updated_at
         """
             ),
             {"d": str(day), "s": out, "u": stamp},
@@ -152,44 +194,55 @@ def build_topics(day: date):
     with eng.begin() as cxn:
         topics = [r[0] for r in cxn.execute(text(SQL_TOPICS_DAY), {"day": str(day)}).all()]
         for t in topics:
-            rows = cxn.execute(text("""
-                select title, summary, published_at, inserted_at
-                from articles
-                where date(coalesce(published_at, inserted_at)) = :day
-                  and coalesce(topic,'general') = :t
-                  and id not in (select article_id from article_dupes)
-                order by coalesce(published_at, inserted_at)
-            """), {"day": str(day), "t": t}).mappings().all()
+            rows = cxn.execute(
+                text("""
+                    select title, summary, published_at, inserted_at
+                    from articles
+                    where date(coalesce(published_at, inserted_at)) = :day
+                      and coalesce(topic,'general') = :t
+                      and id not in (select article_id from article_dupes)
+                    order by coalesce(published_at, inserted_at)
+                """),
+                {"day": str(day), "t": t},
+            ).mappings().all()
+
             if not rows:
                 continue
+
             latest_ts = None
             for r in rows:
-                candidates = [
-                    _parse_dt(r.get("published_at")),
-                    _parse_dt(r.get("inserted_at")),
-                ]
-                article_ts = max((ts for ts in candidates if ts), default=None)
-                article_ts = _normalize_ts(article_ts)
+                article_ts = _latest_ts_from_row(r)
                 if article_ts and (latest_ts is None or article_ts > latest_ts):
                     latest_ts = article_ts
+
             current = cxn.execute(
                 text("select updated_at from topic_summaries where day = :d and topic = :t"),
                 {"d": str(day), "t": t},
             ).mappings().one_or_none()
+
             if current and latest_ts:
                 summary_ts = _normalize_ts(_parse_dt(current.get("updated_at")))
                 if summary_ts and latest_ts <= summary_ts:
                     continue
+
             bundle = "\n".join([f"- {r['title']} — {r['summary'] or ''}" for r in rows])
             prompt = PROMPT_TOPIC.format(topic=t, date=str(day)) + "\n\nARTICLES:\n" + bundle
             out = call_llm(prompt)
             stamp = _now()
-            cxn.execute(text("""
-                insert into topic_summaries(day, topic, summary_md, updated_at)
-                values (:d, :t, :s, :u)
-                on conflict(day, topic) do update set summary_md=excluded.summary_md, updated_at=excluded.updated_at
-            """), {"d": str(day), "t": t, "s": out, "u": stamp})
 
+            cxn.execute(
+                text("""
+                    insert into topic_summaries(day, topic, summary_md, updated_at)
+                    values (:d, :t, :s, :u)
+                    on conflict(day, topic) do update
+                      set summary_md=excluded.summary_md, updated_at=excluded.updated_at
+                """),
+                {"d": str(day), "t": t, "s": out, "u": stamp},
+            )
+
+# ---------------------------------------------------------------------
+# MAIN
+# ---------------------------------------------------------------------
 
 if __name__ == "__main__":
     now = _now()

--- a/src/summarize.py
+++ b/src/summarize.py
@@ -1,13 +1,21 @@
 import os
 import json
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from sqlalchemy import text
 from db import get_engine
 from dotenv import load_dotenv
 
+try:
+    from zoneinfo import ZoneInfo  # py>=3.9
+except ImportError:  # pragma: no cover - fallback for very old python
+    ZoneInfo = None
+
 load_dotenv()
 MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 MAX_TOK = int(os.getenv("SUMMARIZE_MAX_TOKENS", "800"))
+WINDOW_DAYS = max(1, int(os.getenv("SUMMARY_WINDOW_DAYS", "3")))
+MIN_HOUR = int(os.getenv("SUMMARY_MIN_HOUR", "9"))
+TZ_NAME = os.getenv("SUMMARY_TIMEZONE")
 
 PROMPT_DAILY = open("config/prompts/daily_summary.txt", "r", encoding="utf-8").read()
 PROMPT_TOPIC = open("config/prompts/topic_summary.txt", "r", encoding="utf-8").read()
@@ -16,6 +24,22 @@ PROMPT_TOPIC = open("config/prompts/topic_summary.txt", "r", encoding="utf-8").r
 import requests
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_API_BASE = os.getenv("OPENAI_BASE", "https://api.openai.com/v1")
+
+
+def _now() -> datetime:
+    """Return timezone-aware now when possible."""
+    if TZ_NAME:
+        if ZoneInfo is not None:
+            try:
+                return datetime.now(ZoneInfo(TZ_NAME))
+            except Exception:
+                pass
+    if ZoneInfo is not None:
+        try:
+            return datetime.now().astimezone()
+        except Exception:
+            pass
+    return datetime.now()
 
 
 def call_llm(prompt: str) -> str:
@@ -44,6 +68,16 @@ select distinct coalesce(topic, 'general') as topic
 from articles
 where date(coalesce(published_at, inserted_at)) = :day
 """
+
+
+def iter_days(reference: date, now: datetime) -> list[date]:
+    start = reference - timedelta(days=WINDOW_DAYS - 1)
+    days = [start + timedelta(days=i) for i in range(WINDOW_DAYS)]
+    if MIN_HOUR >= 0:
+        cutoff = MIN_HOUR % 24
+        if reference in days and now.hour < cutoff:
+            days = [d for d in days if d != reference]
+    return days
 
 
 def build_daily(day: date):
@@ -87,6 +121,8 @@ def build_topics(day: date):
 
 
 if __name__ == "__main__":
-    today = date.today()
-    build_daily(today)
-    build_topics(today)
+    now = _now()
+    today = now.date()
+    for day in iter_days(today, now):
+        build_daily(day)
+        build_topics(day)


### PR DESCRIPTION
## Summary
- regenerate daily and topic summaries over a configurable sliding window to absorb late articles
- delay day-of summaries until a configurable hour with optional timezone awareness
- document the new environment variables controlling the summarisation behaviour

## Testing
- python -m compileall src/summarize.py

------
https://chatgpt.com/codex/tasks/task_e_68e4349b34b08332a7ef52e87483c59b